### PR TITLE
Fixed Left Shift tapdance in general and for gaming mode.

### DIFF
--- a/keyboards/gmmk/pro/rev1/ansi/keymaps/gourdo1/keymap.c
+++ b/keyboards/gmmk/pro/rev1/ansi/keymaps/gourdo1/keymap.c
@@ -52,7 +52,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,          BELOWENC,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,          KC_PGUP,
         CAPSNUM, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,           KC_PGDN,
-        LSFTCAPSWIN,      KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, KC_UP,   KC_END,
+        KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, KC_UP,   KC_END,
         KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO(_FN1),KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
     ),
 

--- a/keyboards/gmmk/pro/rev1/ansi/keymaps/gourdo1/keymap.c
+++ b/keyboards/gmmk/pro/rev1/ansi/keymaps/gourdo1/keymap.c
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-// Note: Several advanced functions referenced in this file (like Tap Dance functions) are defined in /users/gourdo1/gourdo1.c
+// Note: Many advanced functions referenced in this file are defined in /users/gourdo1/gourdo1.c
 
 #include QMK_KEYBOARD_H
 
@@ -99,7 +99,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, RGB_SAD, RGB_VAI, RGB_SAI, NK_TOGG, _______, YAHOO,   _______, _______, OUTLOOK, KC_PAUS, SWAP_L,  SWAP_R,  QK_BOOT,           KC_HOME,
         KC_CAPS, RGB_HUD, RGB_VAD, RGB_HUI, _______, GMAIL,   HOTMAIL, _______, _______, LOCKPC,  _______, _______,          _______,           KC_END,
         _______,          RGB_NITE,_______, _______, _______, _______, KC_NLCK, _______, _______, DOTCOM,  KC_CAD,           _______, RGB_MOD,  _______,
-        _______, KC_WINLCK, _______,                          _______,                            _______, _______, _______, RGB_SPD, RGB_RMOD, RGB_SPI
+        _______, WINLOCK, _______,                            _______,                            _______, _______, _______, RGB_SPD, RGB_RMOD, RGB_SPI
     ),
     #endif  //GAME_ENABLE
 

--- a/keyboards/gmmk/pro/rev1/ansi/keymaps/gourdo1/rules.mk
+++ b/keyboards/gmmk/pro/rev1/ansi/keymaps/gourdo1/rules.mk
@@ -5,7 +5,7 @@ BOOTMAGIC_ENABLE = yes         # Enable Bootmagic Lite
 VIA_ENABLE = yes
 
 MOUSEKEY_ENABLE = yes
-TAP_DANCE_ENABLE = yes
+TAP_DANCE_ENABLE = no
 CAPS_WORD_ENABLE = yes         # Enable built-in Caps Word functionality
 IDLE_TIMEOUT_ENABLE = yes
 STARTUP_NUMLOCK_ON = yes

--- a/keyboards/gmmk/pro/rev1/iso/keymaps/gourdo1/keymap.c
+++ b/keyboards/gmmk/pro/rev1/iso/keymaps/gourdo1/keymap.c
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-// Note: Several advanced functions referenced in this file (like Tap Dance functions) are defined in /users/gourdo1/gourdo1.c
+// Note: Many advanced functions referenced in this file are defined in /users/gourdo1/gourdo1.c
 
 #include QMK_KEYBOARD_H
 
@@ -100,7 +100,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, RGB_SAD, RGB_VAI, RGB_SAI, NK_TOGG, _______, YAHOO,   _______, _______, OUTLOOK, KC_PAUS, SWAP_L,  SWAP_R,                     KC_HOME,
         KC_CAPS, RGB_HUD, RGB_VAD, RGB_HUI, _______, GMAIL,   HOTMAIL, _______, _______, LOCKPC,  _______, _______, _______, _______,           KC_END,
         _______, RESET,   RGB_NITE,_______, _______, _______, _______, KC_NLCK, _______, _______, DOTCOM,  KC_CAD,           _______, RGB_MOD,  _______,
-        _______, KC_WINLCK, _______,                          _______,                            _______, _______, _______, RGB_SPD, RGB_RMOD, RGB_SPI
+        _______, WINLOCK, _______,                            _______,                            _______, _______, _______, RGB_SPD, RGB_RMOD, RGB_SPI
     ),
     #endif  //GAME_ENABLE
 

--- a/keyboards/gmmk/pro/rev1/iso/keymaps/gourdo1/keymap.c
+++ b/keyboards/gmmk/pro/rev1/iso/keymaps/gourdo1/keymap.c
@@ -53,7 +53,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,          BELOWENC,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,                   KC_PGUP,
         CAPSNUM, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,           KC_PGDN,
-        LSFTCAPSWIN,KC_NUBS, KC_Z, KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, KC_UP,   KC_END,
+        KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, KC_UP,   KC_END,
         KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO(_FN1),KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
     ),
 

--- a/keyboards/gmmk/pro/rev1/iso/keymaps/gourdo1/readme.md
+++ b/keyboards/gmmk/pro/rev1/iso/keymaps/gourdo1/readme.md
@@ -1,6 +1,6 @@
 # [gourdo1's](mailto:gourdo1@outlook.com) GMMK Pro ISO layout
 
-This Windows-centric ISO layout is based on [Jonavin's](https://github.com/qmk/qmk_firmware/tree/master/keyboards/gmmk/pro/rev1/iso/keymaps/jonavin) GMMK Pro layout with several additions, fixes, a tweaked keymap, updated layers, [Tomas Guinan's paddle game](https://github.com/qmk/qmk_firmware/tree/master/keyboards/gmmk/pro/rev1/ansi/keymaps/paddlegame) and expanded RGB controls.
+This Windows-centric ISO layout is based on [Jonavin's](https://github.com/qmk/qmk_firmware/tree/master/keyboards/gmmk/pro/rev1/iso/keymaps/jonavin) GMMK Pro layout with many additions, fixes, a revamped keymap, persistent user customizations, updated layers, [Tomas Guinan's paddle game](https://github.com/qmk/qmk_firmware/tree/master/keyboards/gmmk/pro/rev1/ansi/keymaps/paddlegame) and expanded RGB effects and controls.
 
 ![image](https://raw.githubusercontent.com/gourdo1/media/main/susuwatari.jpg)
 
@@ -9,35 +9,51 @@ This Windows-centric ISO layout is based on [Jonavin's](https://github.com/qmk/q
 ### Core Functionality
 
 * ISO layout (added July xx, 2022)
+* Quick & Easy Customization: Open a text editor and hit [FN]` (tilde key) to view toggle-able features. (added Jun 29, 2022)
 * [VIA](https://www.caniusevia.com/) support enabled (added Mar 16, 2022)
 * Most [default Glorious shortcuts](https://cdn.shopify.com/s/files/1/0549/2681/files/GMMK_Pro_User_Guide.pdf) enabled
-* [N-key Rollover](https://en.wikipedia.org/wiki/Rollover_\(keyboard\)#n-key_rollover) (NKRO) -- toggled with Fn+R
+* [N-key Rollover](https://en.wikipedia.org/wiki/Rollover_\(keyboard\)#n-key_rollover) (NKRO) -- toggled with [FN]R
 * 1000Hz polling rate with 5ms debounce time for quick response in games
-* Mouse Keys! Don't want to move your hands off the keyboard or you didn't bring it with you on the road? Use cursor keys to move the mouse.
+* Mouse Keys! Don't want to move your hands off the keyboard or you didn't bring it with you? Use cursor keys to move the mouse
 * Overlay numpad on 789-UIOP-JKL;-M,. & Space-bar mapped to Enter key for rapid number entry
-* Gaming mode (Fn+Win-key) locks out Win-key as well as double-tap Shift Capslock; Also RGB highlights WSAD and nearby gaming related keys
-* [Caps Word](https://getreuer.info/posts/keyboards/caps-word/index.html) enabled: To capitalize the next word only, press and release both left and right shift keys at the same time. (added Feb 25, 2022)
-* Multi-monitor app moving shortcuts: Fn+[,] (square brackets) to move current app window to next monitor (added Apr 11, 2022)
-* Capslock toggled by double tap of Left Shift key or Fn + Capslock (RGB green highlighted)
-* Paddle game accessible via Fn+P; Hit Fn+P again or double tap ESC to exit (added May 5, 2022)
-* Single-handed shortcut for Ctrl-Alt-Delete: Fn+/ (added May 14, 2022)
-* Single-handed shortcut for Win-L (lock Windows): Fn+L (added May 17, 2022)
-* Domain shortcuts: Fn+.=".com", Fn+O="outlook.com", Fn+Y="yahoo.com", Fn+H="hotmail.com", Fn+G="gmail.com". (added Apr 7, 2022)
-* Fn-Backslash for [Bootloader mode](https://github.com/qmk/qmk_firmware/blob/master/docs/newbs_flashing.md)
+* Gaming mode ([FN]Win-key) locks out Win-key and double-tap Shift Capslock; Also RGB highlights WSAD and nearby gaming keys
+* Caps Word enabled: To capitalize the next word only, press and release left and right shift at the same time. (added Feb 25, 2022)
+* Multi-monitor app moving shortcuts: [FN] ],[ (square brackets) to move current app window to next monitor (added Apr 11, 2022)
+* Capslock toggled by double tap of Left Shift key or FN + Capslock (RGB green highlighted)
+* Paddle game accessible via [FN]P. Hit [FN]P again or double tap [ESC] to exit (added May 5, 2022)
+* Single-handed shortcut for Ctrl-Alt-Delete: [FN]/ (added May 14, 2022)
+* Single-handed shortcut for WinKey-L (lock Windows): [FN]L (added May 17, 2022)
+* Domain shortcuts: [FN]. for .com, [FN]O for outlook.com, [FN]Y for yahoo.com, [FN]H for hotmail.com, [FN]G for gmail.com. (added Apr 7, 2022)
+* FN-Backslash for [Bootloader mode](https://github.com/qmk/qmk_firmware/blob/master/docs/newbs_flashing.md)
 * Home key on F13, Del key right of Backspace
 * Insert accessible via Shift-Backspace (so shift delete still works in Windows Explorer)
-* PrtScrn, Scroll Lock, Pause/Break are top right on the keyboard: Fn+F11, Fn+F12, Fn+F13
-* [Colemak](https://colemak.com/) key layout support (Layer accessible via Left Shift + turn Encoder clockwise until side LEDs light up purple)
+* PrtScrn, Scroll Lock, Pause/Break are top right on the keyboard: [FN]F11, [FN]F12, [FN]F13
+* [Colemak](https://colemak.com/) key layout support (Accessible via Left Shift + turn Encoder clockwise until side LEDs light up purple)
 * Double tap ESC any time to revert to base layer (added Feb 26, 2022)
 * RGB backlight effects expanded to include framebuffer effects and reactive keypress modes (updated May 24, 2022)
 * RGB backlight now remembers last color & effect settings after power down (updated May 24, 2022)
+
+### Quick & Easy Customization
+* Below features can be toggled by holding [FN] and pressing the number corresponding to that feature. Changes are saved to EEPROM for persistence.
+* Print current settings by opening a text editor and pressing [FN]~ (CAUTION: verbose!)
+* Quick view current settings by holding [FN] and viewing RGB under number keys (green means ON, violet means OFF)
+
+#### Toggle-able Settings:
+    1. CapsLock RGB - highlight under alpha keys
+    2. Numpad RGB - highlight under numpad layer keys
+    3. ESC key - Double tap ESC key to go to base layer
+    4. Swap DEL and HOME - Default is DEL to the right of BKSPC & HOME is above BKSPC
+    5. Capslock function - Toggle between double tap LShift for CapsLock with Numpad on CapsLock key (default) and standard CapsLock
+    6. Encoder button - default mutes volume; alternate plays/pauses media
+    7. Insert function - Toggle between SHIFT-BKSPC and SHIFT-DEL
+    8. Modded-Space override - Use standard Space in place of modded-Space functions
 
 ### Numpad + Mouse Keys (Capslock key)
 
 * Overlay numpad + [Mouse Keys](https://github.com/qmk/qmk_firmware/blob/master/docs/feature_mouse_keys.md) are accessed through Capslock key hold (temp) or double press (locked) with RGB highlighting
 * Numpad uses Space-bar as Enter for rapid number entry (added May 17, 2022)
 * This layer disables much of the keyboard, except X/C/V for cut/copy/paste, WASD for cursor, Q/E for PgUp/PgDn, cursor keys become mouse keys, surrounding keys become mouse buttons and all number keys become numpad versions (so Alt char codes work regardless of which set you use)
-* Fn and N keys light up orange if system numlock is off (inverted status), indicating numpad keys will not deliver expected output (Fn+N to toggle)
+* FN and N keys light up orange if system numlock is off (inverted status), indicating numpad keys will not deliver expected output ([FN]N to toggle)
 * Double zero on comma key.
 * [Mouse Keys](https://github.com/qmk/qmk_firmware/blob/master/docs/feature_mouse_keys.md) allow you to use the mouse without taking your hand off the keyboard. (added Mar 15, 2022)
 * Mouse controls are: Cursor keys = move mouse; RShift = button1, End = button2, RCtrl = button3, PgUp/PgDn = Scroll wheel
@@ -47,8 +63,8 @@ This Windows-centric ISO layout is based on [Jonavin's](https://github.com/qmk/q
 
 * Default knob turn changes volume; button press toggles mute
 * Exponential encoder - quick repeated volume up doubles increase; quick repeated volume down triples decrease (added Feb 17, 2022)
-* Fn + knob turn changes RGB idle timeout
-* Fn + knob push puts PC to Sleep (Added May 14, 2022)
+* FN + knob turn changes RGB idle timeout
+* FN + knob push puts PC to Sleep (Added May 14, 2022)
 * holding Left Shift changes layers
 * holding Right Shift navigates page up/down
 * holding Left Ctrl navigates prev/next word
@@ -58,38 +74,38 @@ This Windows-centric ISO layout is based on [Jonavin's](https://github.com/qmk/q
 ### Paddle Game
 
 * Based on [Tomas Guinan's excellent GMMK Pro paddle game](https://github.com/qmk/qmk_firmware/tree/master/keyboards/gmmk/pro/rev1/ansi/keymaps/paddlegame)
-* Paddle Game playable by pressing Fn+P (P lights up green in Fn layer if game is enabled in firmware, otherwise it lights up red)
+* Paddle Game playable by pressing [FN]P (P lights up green in FN layer if game is enabled in firmware, otherwise it lights up red)
 * Use rotary encoder to control paddle
 * Contains 12 levels, indicated by blue LED on F-key row
 * Player has 4 lives, indicated by nav cluster
 * Deflect white balls while avoiding red ones
-* Use Fn+P, double tap ESC or otherwise change layer to quit game
+* Use [FN]P, double tap ESC or otherwise change layer to quit game
 
 ### Global RGB Controls
 
-* RGB backlight lighting effect: Fn+up/down
-* RGB backlight effect speed: Fn+left/right
-* RGB backlight hue cycle: Fn+A/D
-* RGB backlight brightness: Fn+W/S
-* RGB backlight saturation: Fn+Q/E (added Feb 4, 2022)
-* RGB backlight night mode toggle: Fn+Z (indicators still work)
-* RGB backlight timeout: Fn+Encoder or "-" and "=" (default 15 minutes) (updated Apr 7, 2022)
-    * indicators in Fn layer using RGB in F-key and number rows to show the current timeout in minutes
-* Fn+Z to turn off RGB backlighting (indicator lights still work); press again to toggle
-* RGB indicators on left side LEDs in order from top: System NumLock off (orange), Scroll Lock (red), Numpad (blue), Capslock (green).
+* RGB backlight lighting effect: [FN]up/down
+* RGB backlight effect speed: [FN]left/right
+* RGB backlight hue cycle: [FN]A/D
+* RGB backlight brightness: [FN]W/S
+* RGB backlight saturation: [FN]Q/E (added Feb 4, 2022)
+* RGB backlight night mode toggle: [FN]Z (indicators still work)
+* RGB backlight timeout: [FN]Encoder or "-" and "=" (default 15 minutes) (updated June 28, 2022)
+    *  F-key row indicator lights (cyan and blue) in FN layer display the current backlight timeout in minutes
+* [FN]Z to turn off RGB backlighting (indicator lights still work); press again to toggle
+* Left side RGB indicators in order from top: System NumLock off (orange), Scroll Lock (red), Numpad (blue), Capslock (green).
 
 ### Advanced Controls
 
-* Fn+\ to get to bootloader mode
-* Fn+[ESC] to clear EEPROM (then unplug and re-plug) (added Apr 11, 2022)
-* Fn+R to toggle N-key Rollover (added Apr 11, 2022)
-* Fn+/ is single-handed shortcut to Ctrl-Alt-Delete (added May 14, 2022)
-* Fn+L is single-handed shortcut to Win-L (lock Windows) (added May 17, 2022)
-* Fn+[Encoder press] to sleep Windows PC (added May 14, 2022)
+* [FN]\ to get to bootloader mode
+* [FN][ESC] to clear EEPROM (added Apr 11, 2022)
+* [FN]R to toggle N-key Rollover (added Apr 11, 2022)
+* [FN]/ is single-handed shortcut to Ctrl-Alt-Delete (added May 14, 2022)
+* [FN]L is single-handed shortcut to Win-L (lock Windows) (added May 17, 2022)
+* [FN][Encoder press] to sleep Windows PC (added May 14, 2022)
 
-Link to latest firmware binary: https://github.com/gourdo1/media/raw/main/gmmk_pro_rev1_ansi_gourdo1.bin
+Link to latest firmware binary: https://github.com/gourdo1/gmmkpro-media/raw/main/gmmk_pro_rev1_iso_gourdo1.bin
 
-Link to cheatsheet: https://github.com/gourdo1/media/raw/main/GMMK_Pro_Cheatsheet.pdf
+Link to cheatsheet: https://github.com/gourdo1/gmmkpro-media/raw/main/GMMK_Pro_Cheatsheet.pdf
 
 
 ## rules.mk Options
@@ -110,13 +126,13 @@ GAME_ENABLE ?= yes                   - Enables Paddle Game
 
 ## Layer Diagrams
 ### Base layer
-![image](https://raw.githubusercontent.com/gourdo1/media/main/base.png)
+![image](https://raw.githubusercontent.com/gourdo1/gmmkpro-media/main/base.png)
 
-### Fn Layer
-![image](https://raw.githubusercontent.com/gourdo1/media/main/fn1.png)
+### FN Layer
+![image](https://raw.githubusercontent.com/gourdo1/gmmkpro-media/main/fn1.png)
 
 ### Layer 2 (Numpad)
-![image](https://raw.githubusercontent.com/gourdo1/media/main/numpad.png)
+![image](https://raw.githubusercontent.com/gourdo1/gmmkpro-media/main/numpad.png)
 
 ### COLEMAK layer
 ![image](https://user-images.githubusercontent.com/71780717/131235050-980d2f54-2d23-4ae8-a83f-9fcdbe60d6cb.png)

--- a/keyboards/gmmk/pro/rev1/iso/keymaps/gourdo1/readme.md
+++ b/keyboards/gmmk/pro/rev1/iso/keymaps/gourdo1/readme.md
@@ -8,7 +8,7 @@ This Windows-centric ISO layout is based on [Jonavin's](https://github.com/qmk/q
 
 ### Core Functionality
 
-* ISO layout (added July xx, 2022)
+* ISO layout (added July 1, 2022)
 * Quick & Easy Customization: Open a text editor and hit [FN]` (tilde key) to view toggle-able features. (added Jun 29, 2022)
 * [VIA](https://www.caniusevia.com/) support enabled (added Mar 16, 2022)
 * Most [default Glorious shortcuts](https://cdn.shopify.com/s/files/1/0549/2681/files/GMMK_Pro_User_Guide.pdf) enabled

--- a/users/gourdo1/custom_double_taps.h
+++ b/users/gourdo1/custom_double_taps.h
@@ -71,3 +71,28 @@ static bool process_esc_to_base(uint16_t keycode, keyrecord_t * record) {
     }
     return true;
 }
+
+static bool process_lsft_for_caps(uint16_t keycode, keyrecord_t * record) {
+    static bool tapped = false;
+    static uint16_t tap_timer = 0;
+
+    if (keycode == KC_LSFT) {
+        if (user_config.double_tap_shift_for_capslock) {
+          if (record->event.pressed) {
+            if (tapped && !timer_expired(record->event.time, tap_timer)) {
+              // The key was double tapped.
+              clear_mods();  // If needed, clear the mods.
+              // Do something interesting...
+              register_code(KC_CAPS);
+              unregister_code(KC_CAPS);
+            }
+            tapped = true;
+            tap_timer = record->event.time + TAPPING_TERM;
+          } else {
+            // On an event with any other key, reset the double tap state.
+            tapped = false;
+          }
+        }
+    }
+    return true;
+}

--- a/users/gourdo1/custom_double_taps.h
+++ b/users/gourdo1/custom_double_taps.h
@@ -78,21 +78,24 @@ static bool process_lsft_for_caps(uint16_t keycode, keyrecord_t * record) {
 
     if (keycode == KC_LSFT) {
         if (user_config.double_tap_shift_for_capslock) {
-          if (record->event.pressed) {
-            if (tapped && !timer_expired(record->event.time, tap_timer)) {
-              // The key was double tapped.
-              clear_mods();  // If needed, clear the mods.
-              // Do something interesting...
-              register_code(KC_CAPS);
-              unregister_code(KC_CAPS);
+          if (!keymap_config.no_gui) {
+            if (record->event.pressed) {
+                if (tapped && !timer_expired(record->event.time, tap_timer)) {
+                  // The key was double tapped.
+                  //clear_mods();  // If needed, clear the mods.
+                  // Do something interesting...
+                  register_code(KC_CAPS);
+                }
+                tapped = true;
+                tap_timer = record->event.time + TAPPING_TERM;
+            } else {
+                unregister_code(KC_CAPS);
             }
-            tapped = true;
-            tap_timer = record->event.time + TAPPING_TERM;
-          } else {
-            // On an event with any other key, reset the double tap state.
-            tapped = false;
           }
         }
+    } else {
+            // On an event with any other key, reset the double tap state.
+            tapped = false;
     }
     return true;
 }

--- a/users/gourdo1/gourdo1.c
+++ b/users/gourdo1/gourdo1.c
@@ -129,6 +129,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t * record) {
     if (!process_record_keymap(keycode, record)) { return false; }
     if (!process_capsnum(keycode, record)) { return false; }
     if (!process_esc_to_base(keycode, record)) { return false; }
+    if (!process_lsft_for_caps(keycode, record)) { return false; }
 
     // Key macros ...
     switch (keycode) {

--- a/users/gourdo1/gourdo1.c
+++ b/users/gourdo1/gourdo1.c
@@ -21,34 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "custom_double_taps.h"
 
-// Tap once for shift, twice for Caps Lock but only if Win Key is not disabled (also disabled by user.config variable)
-void dance_LSFT_each_tap(qk_tap_dance_state_t * state, void * user_data) {
-    if (user_config.double_tap_shift_for_capslock) {
-        if (state -> count == 1 || keymap_config.no_gui) {
-            register_code(KC_LSFT);
-        } else {
-            register_code(KC_CAPS);
-        }
-    } else {
-        register_code(KC_LSFT);
-    }
-}
-
-void dance_LSFT_reset(qk_tap_dance_state_t * state, void * user_data) {
-    if (state -> count == 1 || keymap_config.no_gui) {
-        unregister_code(KC_LSFT);
-    } else {
-        unregister_code(KC_CAPS);
-        unregister_code(KC_LSFT);
-    }
-}
-
-// Tap Dance definitions
-qk_tap_dance_action_t tap_dance_actions[] = {
-    // Tap once for shift, twice for Caps Lock
-    [TD_LSFT_CAPS_WIN] = ACTION_TAP_DANCE_FN_ADVANCED(dance_LSFT_each_tap, NULL, dance_LSFT_reset)
-};
-
 // RGB NIGHT MODE
 #ifdef RGB_MATRIX_ENABLE
 static bool rgb_nightmode = false;
@@ -573,7 +545,7 @@ bool caps_word_press_user(uint16_t keycode) {
         case KC_DQT:
         case KC_COLN:
         case KC_RSFT:
-        case LSFTCAPSWIN:
+        case KC_LSFT:
             add_weak_mods(MOD_BIT(KC_LSFT));  // Apply shift to next key.
             return true;
 

--- a/users/gourdo1/gourdo1.h
+++ b/users/gourdo1/gourdo1.h
@@ -57,10 +57,10 @@ enum custom_user_keycodes {
 
         TG_CAPS,       // Toggles RGB highlighting of alphas during capslock
         TG_PAD,        // Toggles RGB highlighting of keys on numpad+mousekeys layer
-        TG_TDCAP,      // Toggles double tap shift (tapdance) for CapsLock
+        TG_TDCAP,      // Toggles double tap shift (custom tapdance) for CapsLock
         TG_DEL,        // Swaps DEL and HOME key locations
         TG_ENC,        // Toggle Encoder functionality
-        TG_ESC,        // Toggle ESC tapdance for _BASE layer
+        TG_ESC,        // Toggle ESC custom tapdance for _BASE layer
         TG_INS,        // Toggle location of INS
         TG_SPCMOD,     // Toggle disabling of modded-SPACE functions
 
@@ -80,12 +80,6 @@ enum custom_user_keycodes {
         KC_TSTOG,      // Tab Scroll Toggle
 
         NEW_SAFE_RANGE // New safe range for keymap level custom keycodes
-};
-
-
-// Tap Dance Definitions
-enum custom_tapdance {
-    TD_LSFT_CAPS_WIN,
 };
 
 // Set up boolean variables to track user customizable configuration options


### PR DESCRIPTION
Capslock on double left shift changed from a QMK TapDance to custom code. Now Double tap left-shift for Capslock only engages if [Fn]-5 toggle is ON and Gaming mode ([FN]-[Winkey]) is OFF. If Gaming mode is ON, regardless of [FN]-5 toggle status, capslock will not engage or interfere with left-shift key presses.