### PR TITLE
Let go of KC_CAPS on double tap

### DIFF
--- a/users/gourdo1/custom_double_taps.h
+++ b/users/gourdo1/custom_double_taps.h
@@ -71,25 +71,29 @@ static bool process_esc_to_base(uint16_t keycode, keyrecord_t * record) {
     }
     return true;
 }
+
 static bool process_lsft_for_caps(uint16_t keycode, keyrecord_t * record) {
-    static bool toggled = false;
+    // static bool toggled = false;
     static bool tapped = false;
     static uint16_t tap_timer = 0;
+    led_t led_state = host_keyboard_led_state();
     if (keycode == KC_LSFT) {
         if (user_config.double_tap_shift_for_capslock) {
             if (!keymap_config.no_gui) {
                 if (record -> event.pressed) { // SHIFT pressed
                     // Check whether the key was recently tapped
-                    if (!toggled && tapped && !timer_expired(record -> event.time, tap_timer)) {
+                    if (!led_state.caps_lock && tapped && !timer_expired(record -> event.time, tap_timer)) {
                         // This is a double tap (or possibly a triple tap or more)
                         // CAPS LOCK (on)
                         register_code(KC_CAPS);
-                        toggled = true;
-                    } else if (toggled) {
+                        // toggled = true;
+                    } else if (led_state.caps_lock) {
                         // Single tap OK for toggling CAPS LOCK off
-                        toggled = false;
+                        // toggled = false;
                         tapped = false;
                         register_code(KC_CAPS);
+                    } else {
+                        register_code(KC_LSFT);
                     }
                     // Set that the first tap occurred in a potential double tap
                     tapped = true;
@@ -97,10 +101,11 @@ static bool process_lsft_for_caps(uint16_t keycode, keyrecord_t * record) {
                 } else {
                     // Let go of CAPS LOCK
                     unregister_code(KC_CAPS);
+                    unregister_code(KC_LSFT);
                 }
             }
         } else {
-             // Act as KC_CAPS
+             // Act as KC_LSFT
             if (record -> event.pressed) {
                 register_code(KC_LSFT);
             } else {

--- a/users/gourdo1/custom_double_taps.h
+++ b/users/gourdo1/custom_double_taps.h
@@ -85,6 +85,7 @@ static bool process_lsft_for_caps(uint16_t keycode, keyrecord_t * record) {
                   //clear_mods();  // If needed, clear the mods.
                   // Do something interesting...
                   register_code(KC_CAPS);
+                  unregister_code(KC_CAPS);
                 }
                 tapped = true;
                 tap_timer = record->event.time + TAPPING_TERM;

--- a/users/gourdo1/custom_double_taps.h
+++ b/users/gourdo1/custom_double_taps.h
@@ -71,32 +71,46 @@ static bool process_esc_to_base(uint16_t keycode, keyrecord_t * record) {
     }
     return true;
 }
-
 static bool process_lsft_for_caps(uint16_t keycode, keyrecord_t * record) {
+    static bool toggled = false;
     static bool tapped = false;
     static uint16_t tap_timer = 0;
-
     if (keycode == KC_LSFT) {
         if (user_config.double_tap_shift_for_capslock) {
-          if (!keymap_config.no_gui) {
-            if (record->event.pressed) {
-                if (tapped && !timer_expired(record->event.time, tap_timer)) {
-                  // The key was double tapped.
-                  //clear_mods();  // If needed, clear the mods.
-                  // Do something interesting...
-                  register_code(KC_CAPS);
-                  unregister_code(KC_CAPS);
+            if (!keymap_config.no_gui) {
+                if (record -> event.pressed) { // SHIFT pressed
+                    // Check whether the key was recently tapped
+                    if (!toggled && tapped && !timer_expired(record -> event.time, tap_timer)) {
+                        // This is a double tap (or possibly a triple tap or more)
+                        // CAPS LOCK (on)
+                        register_code(KC_CAPS);
+                        toggled = true;
+                    } else if (toggled) {
+                        // Single tap OK for toggling CAPS LOCK off
+                        toggled = false;
+                        tapped = false;
+                        register_code(KC_CAPS);
+                    }
+                    // Set that the first tap occurred in a potential double tap
+                    tapped = true;
+                    tap_timer = record -> event.time + TAPPING_TERM;
+                } else {
+                    // Let go of CAPS LOCK
+                    unregister_code(KC_CAPS);
                 }
-                tapped = true;
-                tap_timer = record->event.time + TAPPING_TERM;
-            } else {
-                unregister_code(KC_CAPS);
             }
-          }
+        } else {
+             // Act as KC_CAPS
+            if (record -> event.pressed) {
+                register_code(KC_LSFT);
+            } else {
+                unregister_code(KC_LSFT);
+            }
         }
+        return false;
     } else {
-            // On an event with any other key, reset the double tap state.
-            tapped = false;
+        // On an event with any other key, reset the double tap state
+        tapped = false;
     }
     return true;
 }


### PR DESCRIPTION
Let go of KC_CAPS on double tap

## Description

Currently double tap shift presses KC_CAPS and does not let go. Subsequent double tap shift will have no effect as a result

Changes target function that enables double tap shift to press KC_CAPS to follow up with letting go of KC_CAPS

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
